### PR TITLE
feat: add getTasks jiraAPI

### DIFF
--- a/apis/jira.ts
+++ b/apis/jira.ts
@@ -122,7 +122,7 @@ export class JiraAPI {
 	> {
 		const query = [
 			'project = "ROW"',
-			`status IN (Ready, "In Progress") and type in subTaskIssueTypes() and "Job Type[Dropdown]" IN (Backend, Frontend)`,
+			`status IN (Ready, "In Progress") and type in (Subtask, subTaskIssueTypes()) and "Job Type[Dropdown]" IN (Backend, Frontend)`,
 		].filter((index) => !!index).join(' AND ');
 
 		const jql =

--- a/apis/jira.ts
+++ b/apis/jira.ts
@@ -117,7 +117,7 @@ export class JiraAPI {
 		options?: Partial<JiraRequestOptions>,
 	): Promise<
 		JiraRequestOptions & {
-			issues: Issue[];
+			issues: Task[];
 		}
 	> {
 		const query = [

--- a/libs/consume-jira-tasks.ts
+++ b/libs/consume-jira-tasks.ts
@@ -1,0 +1,88 @@
+import { JiraAPI } from '../apis/jira.ts';
+import {
+	ID,
+	JiraRequestOptions,
+	JiraStatus,
+	Trigger,
+	TriggerType,
+} from '../types.ts';
+import isEmpty from 'https://deno.land/x/ramda@v0.27.2/source/isEmpty.js';
+import * as uuid from 'https://deno.land/x/uuid@v0.1.2/mod.ts';
+import getUser from './get-user.ts';
+import { Task } from '../types.ts';
+
+type ProcessedResult = {
+	triggers: Trigger[];
+};
+
+/*
+ * T8: there is tasks in the task board
+ * T9: there is no task assigned to a BE dev
+ */
+
+export default async function consumeJiraTasks(
+	result: ProcessedResult,
+	options?: Partial<JiraRequestOptions>,
+) {
+	const response = await JiraAPI.getTasks(options);
+
+	const checkAndTrigger = (
+		tasks: Task[],
+		status: Task['status'],
+		jobType: Task['jobType'],
+		assignee?: Task['assignee'],
+	) => {
+		const filteredTasks = tasks.filter(
+			(task) =>
+				task.status === status && task.jobType === jobType &&
+				(!assignee || task.assignee === assignee),
+		);
+
+		if (isEmpty(filteredTasks)) {
+			result.triggers.push({
+				id: uuid.V4.uuid() as unknown as ID,
+				type: assignee ? TriggerType.T9 : TriggerType.T8,
+				body: {
+					link:
+						`https://identifi.atlassian.net/jira/software/c/projects/ROW/boards/158`,
+					key: '',
+					recipient: getUser({ jira: '5c7759ef36ce822fe7285181' }),
+					...assignee
+						? { assignee: getUser({ jira: assignee }) }
+						: undefined,
+				},
+			});
+		}
+	};
+
+	checkAndTrigger(response.issues, JiraStatus.READY, 'Frontend');
+	checkAndTrigger(response.issues, JiraStatus.READY, 'Backend');
+
+	const beDevs = [
+		'70121:bdbc5579-d911-4300-a559-0fdde913907b',
+		'5fcfdbcecb350d006830c2b2',
+		'5f98b79f048052006be65464',
+	];
+	beDevs.forEach((dev) => {
+		checkAndTrigger(
+			response.issues,
+			JiraStatus.IN_PROGRESS,
+			'Backend',
+			dev,
+		);
+	});
+
+	console.log(
+		'JIRA page',
+		response.startAt + response.maxResults,
+		response.total,
+	);
+	if ((response.startAt + response.maxResults) < response.total) {
+		return consumeJiraTasks(result, {
+			...options,
+			startAt: response.startAt + response.maxResults,
+		});
+	}
+
+	return result;
+}

--- a/libs/consume-jira-tasks.ts
+++ b/libs/consume-jira-tasks.ts
@@ -1,6 +1,5 @@
 import { JiraAPI } from '../apis/jira.ts';
 import {
-	ID,
 	JiraRequestOptions,
 	JiraStatus,
 	Trigger,
@@ -40,13 +39,12 @@ export default async function consumeJiraTasks(
 
 		if (isEmpty(filteredTasks)) {
 			result.triggers.push({
-				id: uuid.V4.uuid() as unknown as ID,
+				id: [uuid.V4.uuid()],
 				type: assignee ? TriggerType.T9 : TriggerType.T8,
 				body: {
 					link:
 						`https://identifi.atlassian.net/jira/software/c/projects/ROW/boards/158`,
 					key: '',
-					recipient: getUser({ jira: '5c7759ef36ce822fe7285181' }),
 					jobType,
 					...assignee
 						? { assignee: getUser({ jira: assignee }) }

--- a/libs/consume-jira-tasks.ts
+++ b/libs/consume-jira-tasks.ts
@@ -47,6 +47,7 @@ export default async function consumeJiraTasks(
 						`https://identifi.atlassian.net/jira/software/c/projects/ROW/boards/158`,
 					key: '',
 					recipient: getUser({ jira: '5c7759ef36ce822fe7285181' }),
+					jobType,
 					...assignee
 						? { assignee: getUser({ jira: assignee }) }
 						: undefined,

--- a/libs/generate-slack-block.ts
+++ b/libs/generate-slack-block.ts
@@ -80,14 +80,24 @@ export default async function generateSlackBlocks(
 						].filter((r) => !!r).join(' '),
 					);
 				}
+				if (curr.body.assignee?.slack) {
+					accum.assignees.push(
+						[
+							`<@${curr.body.assignee.slack.trim()}>`,
+							curr.body.assignee.emoji || undefined,
+						].filter((r) => !!r).join(' '),
+					);
+				}
 
 				return accum;
 			}, {
 				links: [],
 				recipients: [],
+				assignees: [],
 			} as {
 				links: { href: string; assignee?: string }[];
 				recipients: string[];
+				assignees: string[];
 			});
 
 			let title: string | undefined;
@@ -108,18 +118,26 @@ export default async function generateSlackBlocks(
 			if (type === TriggerType.T6) {
 				title = 'Are we sure these tasks are ready for testing?';
 			}
-
 			if (type === TriggerType.T7) {
 				title = 'Can we check if these cards needs acceptance testing?';
 			}
+			if (type === TriggerType.T8) {
+				title = 'Task board is empty, kindly add new task cards';
+			}
+			if (type === TriggerType.T9) {
+				title = 'The following devs has no assigned task';
+			}
+
 			const text = [
 				`*${title}*`,
-				'>```' +
-				(contents.links.map((index) =>
-					`${index.href}${
-						index.assignee ? ` - ${index.assignee}` : ''
-					}`
-				)).join('\n') + '```',
+				!isEmpty(contents.assignees)
+					? contents.assignees.join('\n')
+					: '>```' +
+						(contents.links.map((index) =>
+							`${index.href}${
+								index.assignee ? ` - ${index.assignee}` : ''
+							}`
+						)).join('\n') + '```',
 			];
 
 			if (!isEmpty(contents.recipients)) {

--- a/libs/process-triggers.ts
+++ b/libs/process-triggers.ts
@@ -8,6 +8,7 @@ import toPairs from 'https://deno.land/x/ramda@v0.27.2/source/toPairs.js';
 import groupBy from 'https://deno.land/x/ramda@v0.27.2/source/groupBy.js';
 import concat from 'https://deno.land/x/ramda@v0.27.2/source/concat.js';
 import consumeJiraIssues from './consume-jira-issues.ts';
+import consumeJiraTasks from './consume-jira-tasks.ts';
 import consumeGithubPullRequests from './consume-github-pull-requests.ts';
 import { SlackBlock, Team, Trigger, TriggerType } from '../types.ts';
 import { GITHUB_REPOSITORIES } from './constants.ts';
@@ -27,6 +28,7 @@ export default async function processTriggers() {
 	// get all triggers and merge them
 	const triggers: Trigger[] = concat(
 		await consumeJiraIssues({ triggers: [] }).then((res) => res.triggers),
+		await consumeJiraTasks({ triggers: [] }).then((res) => res.triggers),
 		await consumeGithubPullRequests({ triggers: [] }, {
 			...GITHUB_REPOSITORIES[Team.NEXIUX],
 		}).then((res) => res.triggers),
@@ -121,9 +123,14 @@ export default async function processTriggers() {
 			if (type === TriggerType.T6) {
 				title = 'Are we sure these tasks are ready for testing?';
 			}
-
 			if (type === TriggerType.T7) {
 				title = 'Can we check if these cards needs acceptance testing?';
+			}
+			if (type === TriggerType.T8) {
+				title = 'Task board is empty, kindly add new task cards';
+			}
+			if (type === TriggerType.T9) {
+				title = 'The following devs has no assigned task';
 			}
 
 			const blocks = [

--- a/types.ts
+++ b/types.ts
@@ -130,6 +130,8 @@ export enum TriggerType {
 	T5 = 'task is not in progress status but have subtask that are already in progress',
 	T6 = 'there are acceptance testing that are in ready or in progress but other subtask are not done yet',
 	T7 = 'there is no acceptance testing',
+	T8 = 'there is tasks in the task board',
+	T9 = 'there is no task assigned to a BE dev',
 }
 
 export type Trigger = {
@@ -138,6 +140,7 @@ export type Trigger = {
 	body: {
 		link: string;
 		key: string;
+		assignee?: User;
 		recipient?: User;
 	};
 	lastTriggeredAt?: string;

--- a/types.ts
+++ b/types.ts
@@ -130,7 +130,7 @@ export enum TriggerType {
 	T5 = 'task is not in progress status but have subtask that are already in progress',
 	T6 = 'there are acceptance testing that are in ready or in progress but other subtask are not done yet',
 	T7 = 'there is no acceptance testing',
-	T8 = 'there is tasks in the task board',
+	T8 = 'there is no tasks in the task board',
 	T9 = 'there is no task assigned to a BE dev',
 }
 
@@ -142,6 +142,7 @@ export type Trigger = {
 		key: string;
 		assignee?: User;
 		recipient?: User;
+		jobType?: 'Backend' | 'Frontend';
 	};
 	lastTriggeredAt?: string;
 };

--- a/types.ts
+++ b/types.ts
@@ -78,6 +78,16 @@ export interface Issue {
 	subTasks: Pick<Issue, 'key' | 'type' | 'status' | 'summary'>[];
 }
 
+export interface Task {
+	key: string;
+	summary: string;
+	assignee: string;
+	reporter: string;
+	status: JiraStatus;
+	type: JiraIssueType;
+	jobType: 'Backend' | 'Frontend';
+}
+
 export type JiraIssueFieldsResponse = {
 	summary: string;
 	issuetype: { id: string };
@@ -86,6 +96,7 @@ export type JiraIssueFieldsResponse = {
 	parent?: { key: string; fields: JiraIssueFieldsResponse };
 	assignee: { accountId: string; displayName: string };
 	reporter: { accountId: string; displayName: string };
+	customfield_10813?: { value: string };
 	statuscategorychangedate: string;
 	updated: string;
 	created: string;


### PR DESCRIPTION
Add getTasks jiraAPI
This will retrieve all subtasks that are in Ready/In Progress. It also includes `Job Type` field in result to determine if the card is for BE/FE
Example Result
```{
  triggers: [
    {
      id: "edcf81b6-9a51-4f21-8f0e-724ec959deba",
      type: "there is no task assigned to a BE dev",
      body: {
        link: "https://identifi.atlassian.net/jira/software/c/projects/ROW/boards/158",
        key: "",
        recipient: {
          department: "BACKEND",
          github: "iammeosjin",
          jira: "5c7759ef36ce822fe7285181",
          name: "John Michael Roa",
          slack: "UFYD1NRGE",
          emoji: ":roa_sleepy:"
        },
        assignee: {
          department: "BACKEND",
          github: "Eerie-Cson",
          jira: "5fcfdbcecb350d006830c2b2",
          name: "Ericson Sacdalan",
          slack: "U037K4PGS0G",
          emoji: ":ericson_smile:"
        }
      }
    }
  ]
}
```
 
Card:https://www.notion.so/highoutput/Add-alert-for-A8-75b3c6d76b56422dae89899f262fea42?pvs=4